### PR TITLE
Update youtube-subscribers.js

### DIFF
--- a/js/youtube-subscribers.js
+++ b/js/youtube-subscribers.js
@@ -17,8 +17,10 @@ const youtube_subscribers = {
         const scale = Math.pow(10, tier * 3);
 
         const scaled = number / scale;
-
-        return ( (number >= 9999) ? ~~scaled : scaled.toFixed(1) ) + ' ' + sufix;
+        
+        const scaledOneDigit = Math.trunc(scaled * 10) / 10 ;
+        
+        return ( (number >= 9999) ? ~~scaledOneDigit : scaledOneDigit ) + ' ' + sufix;
     }
 
 }


### PR DESCRIPTION
Assisti quase agora o vídeo e fiquei curioso demais sobre a operação do bitwise, pois eu tinha esquecido o que tinha estudado. 
Eu fiquei curioso também porque vocÊ colocou o `>=` em vez do `>`. Fui testar e vi que não estava funcionando porque o `toFixed()` arredonda quando necessário (9.9999 para 10, por exemplo). Pensei em duas manerias de resolver: 1- transformando em string e copiando uma substring OU 2- o método que escolhi, que foi truncar o número, removendo toda a parte decimal, mas para não perder a informação de 1 casa decimal, multipliquei por 10 antes da operação de truncar, e logo após a operação, dividi por 10, para o valor voltar ao seu canto de origem. Com REGEX eu ainda não sei fazer.